### PR TITLE
Fixed state integer type

### DIFF
--- a/odrive_can.h
+++ b/odrive_can.h
@@ -95,7 +95,7 @@ typedef enum {
 
 typedef struct {
     uint32_t axis_error;
-    uint32_t axis_current_state;
+    uint8_t axis_current_state;
 } ODriveHeartbeat;
 
 typedef struct {


### PR DESCRIPTION
As seen in:
https://docs.odriverobotics.com/v/0.5.5/can-protocol.html

![image](https://user-images.githubusercontent.com/6027644/192114804-950ead1c-4cad-434c-a98e-c3ca3b0193f7.png)

Second value is unsigned 8 bit int, causes issues when controller status is not zero